### PR TITLE
同步 ICP 备案系统 API 于 9 月 2 日的更新

### DIFF
--- a/ICP-Checker.py
+++ b/ICP-Checker.py
@@ -39,7 +39,7 @@ def query_base():
                     raise ValueError("ValidType")
                 else:
                     info_result = info_result.group()
-            info_data = {'pageNum': '1', 'pageSize': '40', 'unitName': info_result}
+            info_data = {'pageNum': '1', 'pageSize': '40', 'serviceType': 1, 'unitName': info_result}
             return info_data
         except ValueError as e:
             if str(e) == 'InputNone' or str(e) == 'OnlyDomainInput':
@@ -146,7 +146,7 @@ def get_beian_info(info_data, p_uuid, token, sign):
                     domain_content_approved = "无"
                 row_data = domain_owner, domain_name, domain_licence, website_licence, domain_type, domain_content_approved, domain_status, domain_approve_date
                 domain_list.append(row_data)
-            info_data = {'pageNum': i + 2, 'pageSize': '40', 'unitName': info}
+            info_data = {'pageNum': i + 2, 'pageSize': '40', 'serviceType': 1, 'unitName': info}
             if beian_info['params']['isLastPage'] is True:
                 break
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-opencv_python==4.5.5.64
-openpyxl==3.0.9
-requests==2.26.0
+opencv_python~=4.8.0.76
+openpyxl~=3.1.2
+requests~=2.31.0


### PR DESCRIPTION
备案系统支持了 App 小程序等多类型备案的查询, 现在接口需要携带 `serviceType` 参数才能正确查询, 否则返回 `HTTP 500`.